### PR TITLE
Reworked the stock watchlist screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,7 @@ This application is built using modern Android development practices and leverag
 
 ## How it Looks (WIP - making changes everyday now)
 
-Watchlist Screen | Single Stock Screen
-------|-------
-![image](https://github.com/user-attachments/assets/d9f94f67-8b3b-439b-b0cf-545e1f52aacb) | ![image](https://github.com/user-attachments/assets/52b61004-06a6-4d00-bdca-dad65f56f3ab)
-
-### Last Update (still in development)
-
-https://github.com/user-attachments/assets/3d330df0-d389-4bf8-9076-354e697e6c13
+https://github.com/user-attachments/assets/2cd2c3cb-84db-4e3d-a1f9-d15368438bc2
 
 ## Key Features
 
@@ -63,6 +57,7 @@ The application follows a clean architecture, separating concerns into distinct 
 
 *   **Match Watchlist screen to single stock screen:** I want to have a more consistent UI maybe have the same card design but smaller with less info, and see the second screen on tap
 *   **Stock Search and Add to Watchlist:** Implement a search functionality (through and api) to allow users to find stocks and add them to their watchlist.
+*   **Watchlist screen should get % from service** Right now its mocked data I would like it to be from a service, but I don't want to make N calls to get percentages. I need to check if it can be fetched on bulk.
 *   **Error Handling:** Implement robust error handling for network requests, data parsing, and other potential issues, providing informative feedback to the user.
 *   **UI Compose Testing:** Address the current issues with running Compose tests to ensure the UI is thoroughly tested.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,8 +94,8 @@ dependencies {
     testImplementation(libs.androidx.core.testing)
     testImplementation(libs.androidx.compose.junit4)
     testImplementation(libs.androidx.test.orchestrator)
-    testImplementation("io.mockk:mockk-android:1.13.16")
-    testImplementation("io.mockk:mockk-agent:1.13.16")
+    testImplementation(libs.mockk.android)
+    testImplementation(libs.mockk.agent)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -141,6 +141,7 @@ tasks.create("jacocoTestReport", JacocoReport::class.java) {
         "**/dto/**/*.*",
         "**/database/**/*.*",
         "**/navigation/**/*.*",
+        "**/previewsrepositories/**/*.*",
         "**/composables/**", // exclude files in composable folders
         "**/*Composable*.*", // exclude files with "composable" in their name
         "**/*Composable*.*", // exclude files with "composable" in their name

--- a/app/src/main/java/com/section11/mystock/di/MyStockModule.kt
+++ b/app/src/main/java/com/section11/mystock/di/MyStockModule.kt
@@ -13,6 +13,8 @@ import com.section11.mystock.data.service.StocksInformationService
 import com.section11.mystock.domain.repositories.StockWatchlistRepository
 import com.section11.mystock.domain.repositories.StocksInformationRepository
 import com.section11.mystock.domain.watchlist.StockWatchlistUseCase
+import com.section11.mystock.framework.featureflags.FeatureFlagManager
+import com.section11.mystock.framework.featureflags.LocalFeatureFlagManager
 import com.section11.mystock.framework.resource.ResourceProviderImpl
 import dagger.Binds
 import dagger.Module
@@ -82,6 +84,11 @@ abstract class MyStockModule {
 
         @Provides
         fun provideIODispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+        @Provides
+        fun provideFeatureFlagManager(): FeatureFlagManager {
+            return LocalFeatureFlagManager()
+        }
 
         @Provides
         fun provideStockInformationRemoteRepository(): StocksInformationRepository {

--- a/app/src/main/java/com/section11/mystock/framework/featureflags/FeatureFlagManager.kt
+++ b/app/src/main/java/com/section11/mystock/framework/featureflags/FeatureFlagManager.kt
@@ -1,0 +1,26 @@
+package com.section11.mystock.framework.featureflags
+
+/**
+ * Manager for feature flags.
+ *
+ * It contains methods which return booleans representing if a feature is enabled or not
+ */
+interface FeatureFlagManager {
+
+    /**
+     * Feature flag for navigation to SingleStock screen. If its enabled tapping on a stock will
+     * navigate to single stock screen. If its disabled it will show extra information on the same
+     * screen, enlarging the card.
+     */
+    fun isNavigationToSingleStockEnabled(): Boolean
+}
+
+/**
+ * For now is just going to have some hard coded flags. I want to implement a RemoteFeatureFlagManager
+ * that calls a service, like Apiary, which returns a JSON with the configuration of the feature flags.
+ * That way the value of the flag can be fetched at runtime and changed with the app "live"
+ */
+class LocalFeatureFlagManager: FeatureFlagManager {
+
+    override fun isNavigationToSingleStockEnabled(): Boolean = false
+}

--- a/app/src/main/java/com/section11/mystock/framework/utils/PreviewUtils.kt
+++ b/app/src/main/java/com/section11/mystock/framework/utils/PreviewUtils.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.tooling.preview.Preview
 // added to avoid detekt error, using @Suppress is not working. need to find a better solution for this
 class PreviewUtils
 
-@Preview(name = "Dark Mode", showBackground = true, uiMode = UI_MODE_NIGHT_YES)
-@Preview(name = "Light Mode", showBackground = true, uiMode = UI_MODE_NIGHT_NO)
+@Preview(name = "Dark Mode", showBackground = true, uiMode = UI_MODE_NIGHT_YES, showSystemUi = true)
+@Preview(name = "Light Mode", showBackground = true, uiMode = UI_MODE_NIGHT_NO, showSystemUi = true)
 annotation class DarkAndLightPreviews
-

--- a/app/src/main/java/com/section11/mystock/ui/common/composables/StockCard.kt
+++ b/app/src/main/java/com/section11/mystock/ui/common/composables/StockCard.kt
@@ -1,0 +1,110 @@
+package com.section11.mystock.ui.common.composables
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.section11.mystock.framework.utils.DarkAndLightPreviews
+import com.section11.mystock.ui.theme.LocalSpacing
+import com.section11.mystock.ui.theme.MyStockTheme
+
+@Composable
+fun StockCard(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val spacing = LocalSpacing.current
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Card(
+            shape = RoundedCornerShape(spacing.medium),
+            modifier = Modifier.fillMaxWidth(),
+            elevation = CardDefaults.cardElevation(defaultElevation = spacing.smallest)
+        ) {
+            Column(
+                modifier = Modifier.padding(spacing.medium),
+                verticalArrangement = Arrangement.spacedBy(spacing.small)
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+fun ExpandableStockCard(
+    modifier: Modifier = Modifier,
+    isExpanded: Boolean,
+    onExpandedContentNeeded: () -> Unit,
+    expandedContent: @Composable () -> Unit,
+    content: @Composable () -> Unit
+) {
+    StockCard(
+        modifier = modifier
+            .animateContentSize()
+            .clickable {
+                onExpandedContentNeeded()
+            }
+    ) {
+        content()
+        if (isExpanded) {
+            expandedContent()
+        }
+    }
+}
+
+@DarkAndLightPreviews
+@Composable
+fun StockCardPreview() {
+    MyStockTheme {
+        Surface {
+            StockCard(modifier = Modifier.statusBarsPadding()) {
+                Text("Testing - Testing")
+            }
+        }
+    }
+}
+
+/**
+ * Use interactive mode to see expanded card
+ */
+@DarkAndLightPreviews
+@Composable
+fun ExpandableStockCardPreview() {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    MyStockTheme {
+        Surface {
+            ExpandableStockCard(
+                modifier = Modifier.statusBarsPadding(),
+                isExpanded = isExpanded,
+                onExpandedContentNeeded = { isExpanded = !isExpanded },
+                expandedContent = {
+                    Text(
+                        text = "Expanded Content Here",
+                        modifier = Modifier.padding(20.dp)
+                    )
+                }
+            ) {
+                Text("This is the title")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/section11/mystock/ui/common/previewsrepositories/FakeRepositoryForPreviews.kt
+++ b/app/src/main/java/com/section11/mystock/ui/common/previewsrepositories/FakeRepositoryForPreviews.kt
@@ -1,0 +1,72 @@
+package com.section11.mystock.ui.common.previewsrepositories
+
+import android.content.Context
+import com.section11.mystock.domain.models.GraphInformation
+import com.section11.mystock.domain.models.GraphNode
+import com.section11.mystock.domain.models.PriceMovement
+import com.section11.mystock.domain.models.Stock
+import com.section11.mystock.domain.models.StockInformation
+import com.section11.mystock.domain.models.Summary
+import com.section11.mystock.framework.resource.ResourceProviderImpl
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.FetchedSingleStockInfo
+import com.section11.mystock.ui.model.StockInformationUiModel
+import com.section11.mystock.ui.model.WatchlistStockModel
+import com.section11.mystock.ui.model.mapper.StockInformationUiModelMapper
+import com.section11.mystock.ui.model.mapper.StockWatchlistUiModelMapper
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.random.Random
+
+private const val DEFAULT_STOCKS_LIST_SIZE = 5
+private const val DEFAULT_GRAPH_NODES_SIZE = 200
+
+@Suppress("MagicNumber") // Suppress warning for mock information on the preview
+class FakeRepositoryForPreviews(context: Context) {
+
+    private val stockWatchlistUiModelMapper = StockWatchlistUiModelMapper(ResourceProviderImpl(context))
+    private val singleStockUiMapper = StockInformationUiModelMapper(ResourceProviderImpl(context))
+
+    fun getStockWatchlist(size: Int = DEFAULT_STOCKS_LIST_SIZE): List<WatchlistStockModel> {
+        val stocks = List(size) { index ->
+            Stock("Microsoft $index", "MSFT")
+        }
+        return stockWatchlistUiModelMapper.mapToUiModel(stocks)
+
+
+    }
+
+    fun getSingleStockInfoStateSuccess(): StateFlow<SingleStockInformationState> {
+        return MutableStateFlow<SingleStockInformationState>(
+            FetchedSingleStockInfo(getSingleStockInformationUiModel())
+        )
+    }
+
+    fun getSingleStockInformationUiModel(): StockInformationUiModel {
+        val stockInfo = StockInformation(
+            Summary(
+                title = "Apple Inc.",
+                stock = "AAPL",
+                exchange = "NASDAQ",
+                price = "$426.32",
+                currency = "$",
+                priceMovement = PriceMovement(
+                    percentage = 2.561525,
+                    value = 10.647491,
+                    movement = "Up"
+                )
+            ),
+            graph = GraphInformation(
+                graphNodes = List(DEFAULT_GRAPH_NODES_SIZE) { index ->
+                    GraphNode(
+                        price = Random.nextDouble(100.0, 200.0),
+                        dateLabel = "Date $index:$index"
+                    )
+                },
+                horizontalAxisLabels = listOf("08:31", "08:36", "08:40", "08:45")
+            )
+        )
+
+        return singleStockUiMapper.mapToUiModel(stockInfo)
+    }
+}

--- a/app/src/main/java/com/section11/mystock/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/section11/mystock/ui/home/HomeViewModel.kt
@@ -2,36 +2,113 @@ package com.section11.mystock.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.section11.mystock.domain.StocksInformationUseCase
+import com.section11.mystock.domain.exceptions.ApiErrorException
+import com.section11.mystock.domain.exceptions.ResponseBodyNullException
 import com.section11.mystock.domain.watchlist.StockWatchlistUseCase
-import com.section11.mystock.domain.models.Stock
+import com.section11.mystock.framework.featureflags.FeatureFlagManager
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Error
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Loading
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Success
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.ErrorFetchingSingleStockInfo
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.FetchedSingleStockInfo
+import com.section11.mystock.ui.model.StockInformationUiModel
+import com.section11.mystock.ui.model.WatchlistStockModel
+import com.section11.mystock.ui.model.mapper.StockInformationUiModelMapper
+import com.section11.mystock.ui.model.mapper.StockWatchlistUiModelMapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-sealed interface HomeUiState {
-    data object Loading : HomeUiState
-    data class Success(val stocks: List<Stock>) : HomeUiState
-    data class Error(val message: String) : HomeUiState
-}
+private const val INVALID_SYMBOL_ERROR = "Invalid symbol"
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val stockWatchlistUseCase: StockWatchlistUseCase,
+    private val stockWatchlistUiModelMapper: StockWatchlistUiModelMapper,
+    private val stocksInformationUseCase: StocksInformationUseCase,
+    private val stockInformationUiModelMapper: StockInformationUiModelMapper,
+    private val featureFlagManager: FeatureFlagManager,
     private val dispatcher: CoroutineDispatcher
 ): ViewModel() {
-    private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+
+    private val _uiState = MutableStateFlow<HomeUiState>(Loading)
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    private val _navigationEvent = MutableSharedFlow<NavigationEvent>()
+    val navigationEvent: SharedFlow<NavigationEvent> = _navigationEvent
+
+    private val _singleStockInformationState = MutableStateFlow<SingleStockInformationState>(
+        SingleStockInformationState.Idle
+    )
+    val singleStockInformationState: StateFlow<SingleStockInformationState> =
+        _singleStockInformationState.asStateFlow()
 
     fun getStocks() {
         viewModelScope.launch(dispatcher) {
             stockWatchlistUseCase.getWatchlist().collect { stocks ->
-                _uiState.update { HomeUiState.Success(stocks) }
+                _uiState.update {
+                    Success(stockWatchlistUiModelMapper.mapToUiModel(stocks))
+                }
             }
         }
+    }
+
+    fun onStockTap(symbol: String?) {
+        if (symbol == null) {
+            _uiState.update { Error(INVALID_SYMBOL_ERROR) }
+            return
+        } else
+
+            viewModelScope.launch(dispatcher) {
+                if (featureFlagManager.isNavigationToSingleStockEnabled()) {
+                    _navigationEvent.emit(NavigationEvent.ToSingleStock(symbol))
+                } else {
+                    _singleStockInformationState.emit(SingleStockInformationState.Loading)
+                    getSingleStockInformation(symbol)
+                }
+            }
+    }
+
+    private suspend fun getSingleStockInformation(symbol: String) {
+        try {
+            val stockResult = stocksInformationUseCase.getStockInformation(symbol)
+            val stockUiModel = stockInformationUiModelMapper.mapToUiModel(stockResult)
+            _singleStockInformationState.emit(FetchedSingleStockInfo(stockUiModel))
+        } catch (nullBodyException: ResponseBodyNullException) {
+            _singleStockInformationState.update {
+                ErrorFetchingSingleStockInfo(nullBodyException.message)
+            }
+        } catch (apiErrorException: ApiErrorException) {
+            _singleStockInformationState.update {
+                ErrorFetchingSingleStockInfo(apiErrorException.message)
+            }
+        }
+    }
+
+    sealed class HomeUiState {
+        data object Loading: HomeUiState()
+        data class Error(val message: String?): HomeUiState()
+        data class Success(val stocks: List<WatchlistStockModel>): HomeUiState()
+    }
+
+    sealed class SingleStockInformationState {
+        data object Loading: SingleStockInformationState()
+        data class FetchedSingleStockInfo(
+            val stockInfo: StockInformationUiModel
+        ): SingleStockInformationState()
+        data class ErrorFetchingSingleStockInfo(val message: String?): SingleStockInformationState()
+        data object Idle: SingleStockInformationState()
+    }
+
+    sealed class NavigationEvent {
+        data class ToSingleStock(val symbol: String) : NavigationEvent()
     }
 }

--- a/app/src/main/java/com/section11/mystock/ui/home/composables/HomeScreen.kt
+++ b/app/src/main/java/com/section11/mystock/ui/home/composables/HomeScreen.kt
@@ -1,47 +1,77 @@
 package com.section11.mystock.ui.home.composables
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
-import com.section11.mystock.domain.models.Stock
-import com.section11.mystock.ui.home.HomeUiState
-import com.section11.mystock.ui.home.HomeUiState.Loading
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import com.section11.mystock.framework.utils.DarkAndLightPreviews
+import com.section11.mystock.ui.common.composables.ExpandableStockCard
+import com.section11.mystock.ui.common.previewsrepositories.FakeRepositoryForPreviews
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.ErrorFetchingSingleStockInfo
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.FetchedSingleStockInfo
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.Idle
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.Loading
+import com.section11.mystock.ui.model.WatchlistStockModel
+import com.section11.mystock.ui.singlestock.composables.SingleStockCardContent
 import com.section11.mystock.ui.theme.LocalSpacing
+import com.section11.mystock.ui.theme.MyStockTheme
+import kotlinx.coroutines.flow.StateFlow
+
+private const val NO_STOCK_SELECTED = -1
+private const val ANIM_DURATION = 300
 
 @Composable
-fun HomeScreenStockList(
+fun StockList(
     modifier: Modifier = Modifier,
-    uiState: HomeUiState,
-    onStockTap: (Stock) -> Unit
+    stocks: List<WatchlistStockModel>,
+    onStockTap: (WatchlistStockModel) -> Unit,
+    singleStockInfoState: StateFlow<SingleStockInformationState>
 ) {
-    when (uiState) {
-        is Loading -> FullScreenLoading()
-        is HomeUiState.Success -> StockList(
-            modifier = modifier,
-            stocks = uiState.stocks,
-            onStockTap = { stock -> onStockTap(stock) }
-        )
-        is HomeUiState.Error -> Text("Error")
+    var expandedCardIndex by remember { mutableIntStateOf(NO_STOCK_SELECTED) }
+
+    val spacing = LocalSpacing.current
+    LazyColumn {
+        item { SectionTitle("Your Watchlist") }
+        item { Spacer(modifier.height(spacing.small)) }
+        items(stocks.size) { index ->
+            StockRowItem(
+                modifier.padding(spacing.small),
+                stock = stocks[index],
+                onStockTap = { stockWatchlist ->
+                    expandedCardIndex = if (expandedCardIndex == index) NO_STOCK_SELECTED else index
+                    onStockTap(stockWatchlist)
+                },
+                singleStockInfoState = singleStockInfoState,
+                isExpanded = index == expandedCardIndex
+            )
+        }
     }
 }
 
@@ -52,11 +82,11 @@ fun SectionTitle(title: String, modifier: Modifier = Modifier) {
         modifier = modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.primaryContainer)
-            .padding(spacing.medium)
+            .padding(spacing.small)
     ) {
         Text(
-            style = MaterialTheme.typography.titleMedium,
-            modifier = modifier.padding(top = spacing.medium),
+            style = MaterialTheme.typography.titleLarge,
+            modifier = modifier.padding(top = spacing.large),
             text = title,
             color = MaterialTheme.colorScheme.onPrimaryContainer
         )
@@ -64,58 +94,84 @@ fun SectionTitle(title: String, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun StockList(modifier: Modifier = Modifier, stocks: List<Stock>, onStockTap: (Stock) -> Unit) {
-    val spacing = LocalSpacing.current
-    LazyColumn(modifier = modifier) {
-        item { SectionTitle("Your Watchlist") }
-        items(stocks.size) { index ->
-            Column(modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant)) {
-                StockRowItem(stock = stocks[index], onStockTap = onStockTap)
-                HorizontalDivider(color = Color.Gray, thickness = spacing.smallest)
+fun StockRowItem(
+    modifier: Modifier = Modifier,
+    stock: WatchlistStockModel,
+    onStockTap: (WatchlistStockModel) -> Unit,
+    singleStockInfoState: StateFlow<SingleStockInformationState>,
+    isExpanded: Boolean
+) {
+    ExpandableStockCard(
+        modifier = modifier,
+        isExpanded = isExpanded,
+        onExpandedContentNeeded = { onStockTap(stock) },
+        expandedContent = { SingleStockInfoExpandedContent(singleStockInfoState) }
+    ) {
+        AnimatedVisibility(
+            visible = !isExpanded,
+            enter = fadeIn(tween(ANIM_DURATION)) + expandVertically(
+                tween(ANIM_DURATION),
+                expandFrom = Alignment.Top
+            ),
+            exit = fadeOut(tween(ANIM_DURATION)) + shrinkVertically(tween(ANIM_DURATION))
+        ) {
+            Row {
+                Text(
+                    text = stock.stockTitle,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+                Column(
+                    modifier = Modifier.align(Alignment.CenterVertically)
+                ) {
+                    Text(
+                        text = "5%", // todo should come from service
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = Color.Green,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-fun StockRowItem(modifier: Modifier = Modifier, stock: Stock, onStockTap: (Stock) -> Unit) {
+fun SingleStockInfoExpandedContent(singleStockInfoState: StateFlow<SingleStockInformationState>) {
+    val singleStockInfo by singleStockInfoState.collectAsState()
     val spacing = LocalSpacing.current
-    Row(modifier = modifier.clickable { onStockTap(stock) }) {
-        Icon(
-            imageVector = Icons.Default.Star,
-            modifier = modifier
-                .padding(spacing.small)
-                .align(Alignment.CenterVertically),
-            contentDescription = null
-        )
-        Text(
-            text = "${stock.symbol} - ${stock.name}",
-            modifier = modifier
-                .padding(spacing.small)
-                .align(Alignment.CenterVertically)
-        )
-        Spacer(modifier = modifier.weight(1f))
-        Text(
-            text = "2.5%",
-            modifier = modifier.padding(spacing.medium)
-        )
+
+    when (singleStockInfo) {
+        is ErrorFetchingSingleStockInfo -> {
+            Text("Error: ${(singleStockInfo as ErrorFetchingSingleStockInfo).message}")
+        }
+        is FetchedSingleStockInfo -> {
+            SingleStockCardContent(
+                stockInformationUiModel = (singleStockInfo as FetchedSingleStockInfo).stockInfo
+            )
+        }
+        is Idle -> Spacer(Modifier)
+        is Loading -> Box(modifier = Modifier.fillMaxWidth().padding(vertical = spacing.medium)) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
     }
 }
 
-@Composable
-private fun FullScreenLoading() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .wrapContentSize(Alignment.Center)
-    ) {
-        CircularProgressIndicator()
-    }
-}
-
-@Preview(showBackground = true)
+@DarkAndLightPreviews
 @Composable
 fun HomeScreenStockListPreview() {
-    val mockUiState = HomeUiState.Success(listOf(Stock("Apple", "AAPL")))
-    HomeScreenStockList(uiState = mockUiState, onStockTap = {})
+    val fakeRepo = FakeRepositoryForPreviews(LocalContext.current)
+    MyStockTheme {
+        Surface {
+            StockList(
+                stocks = fakeRepo.getStockWatchlist(),
+                onStockTap = {},
+                singleStockInfoState = fakeRepo.getSingleStockInfoStateSuccess()
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/section11/mystock/ui/model/WatchlistStockModel.kt
+++ b/app/src/main/java/com/section11/mystock/ui/model/WatchlistStockModel.kt
@@ -1,0 +1,6 @@
+package com.section11.mystock.ui.model
+
+data class WatchlistStockModel(
+    val stockTitle: String,
+    val symbol: String
+)

--- a/app/src/main/java/com/section11/mystock/ui/model/mapper/StockWatchlistUiModelMapper.kt
+++ b/app/src/main/java/com/section11/mystock/ui/model/mapper/StockWatchlistUiModelMapper.kt
@@ -1,0 +1,25 @@
+package com.section11.mystock.ui.model.mapper
+
+import com.section11.mystock.R
+import com.section11.mystock.common.resources.ResourceProvider
+import com.section11.mystock.domain.models.Stock
+import com.section11.mystock.ui.model.WatchlistStockModel
+import javax.inject.Inject
+
+class StockWatchlistUiModelMapper@Inject constructor(
+    private val resourceProvider: ResourceProvider
+) {
+
+    fun mapToUiModel(stocks: List<Stock>): List<WatchlistStockModel> {
+        return stocks.map { stock ->
+            WatchlistStockModel(
+                stockTitle = getStockTitle(stock),
+                symbol = stock.symbol
+            )
+        }
+    }
+
+    private fun getStockTitle(stock: Stock): String {
+        return resourceProvider.getString(R.string.watchlist_stock_tile, stock.name, stock.symbol)
+    }
+}

--- a/app/src/main/java/com/section11/mystock/ui/navigation/HomeRoute.kt
+++ b/app/src/main/java/com/section11/mystock/ui/navigation/HomeRoute.kt
@@ -1,21 +1,60 @@
 package com.section11.mystock.ui.navigation
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import com.section11.mystock.ui.home.HomeViewModel
-import com.section11.mystock.ui.home.composables.HomeScreenStockList
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Error
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Loading
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Success
+import com.section11.mystock.ui.home.HomeViewModel.NavigationEvent.ToSingleStock
+import com.section11.mystock.ui.home.composables.StockList
 
 @Composable
 fun HomeRoute(homeViewModel: HomeViewModel, navigateToSingleStock: (String) -> Unit) {
     val uiState by homeViewModel.uiState.collectAsState()
+
     LaunchedEffect(Unit) {
         homeViewModel.getStocks()
     }
 
-    HomeScreenStockList(
-        uiState = uiState,
-        onStockTap = { stock -> navigateToSingleStock(stock.symbol) }
-    )
+    // Collect navigation events
+    LaunchedEffect(homeViewModel.navigationEvent) {
+        homeViewModel.navigationEvent.collect { event ->
+            when (event) {
+                is ToSingleStock -> navigateToSingleStock(event.symbol)
+            }
+        }
+    }
+
+    when (uiState) {
+        is Loading -> FullScreenLoading()
+        is Success -> StockList(
+            stocks = (uiState as Success).stocks,
+            onStockTap = { stock ->
+                homeViewModel.onStockTap(stock.symbol)
+            },
+            singleStockInfoState = homeViewModel.singleStockInformationState
+        )
+        is Error -> Text("Error: ${(uiState as Error).message}")
+    }
+}
+
+@Composable
+private fun FullScreenLoading() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .wrapContentSize(Alignment.Center)
+    ) {
+        CircularProgressIndicator()
+    }
 }

--- a/app/src/main/java/com/section11/mystock/ui/navigation/SingleStockViewRoute.kt
+++ b/app/src/main/java/com/section11/mystock/ui/navigation/SingleStockViewRoute.kt
@@ -15,6 +15,6 @@ fun SingleStockViewRoute(stockSymbol: String?, singleStockViewModel: SingleStock
     }
 
     (uiState as? SingleStockViewModel.SingleStockUiState.Success)?.let { successState ->
-        SingleStockScreen(successState)
+        SingleStockScreen(successState.stockInformationUiModel)
     }
 }

--- a/app/src/main/java/com/section11/mystock/ui/singlestock/SingleStockViewModel.kt
+++ b/app/src/main/java/com/section11/mystock/ui/singlestock/SingleStockViewModel.kt
@@ -45,8 +45,8 @@ class SingleStockViewModel @Inject constructor(
                 _uiState.update { SingleStockUiState.Error(apiErrorException.message) }
             }
         }
-
     }
+
     sealed class SingleStockUiState {
         data object Loading : SingleStockUiState()
         data class Success(val stockInformationUiModel: StockInformationUiModel) : SingleStockUiState()

--- a/app/src/main/java/com/section11/mystock/ui/singlestock/composables/SingleStockScreen.kt
+++ b/app/src/main/java/com/section11/mystock/ui/singlestock/composables/SingleStockScreen.kt
@@ -1,16 +1,11 @@
 package com.section11.mystock.ui.singlestock.composables
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -18,53 +13,57 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import com.section11.mystock.framework.utils.DarkAndLightPreviews
 import com.section11.mystock.ui.common.composables.SmallBodyText
-import com.section11.mystock.ui.model.GraphUiModel
+import com.section11.mystock.ui.common.composables.StockCard
+import com.section11.mystock.ui.common.previewsrepositories.FakeRepositoryForPreviews
 import com.section11.mystock.ui.model.StockInformationUiModel
-import com.section11.mystock.ui.singlestock.SingleStockViewModel
 import com.section11.mystock.ui.singlestock.graph.composables.LineGraph
-import com.section11.mystock.ui.theme.Green
 import com.section11.mystock.ui.theme.LocalSpacing
 import com.section11.mystock.ui.theme.MyStockTheme
 
 @Composable
-fun SingleStockScreen(uiState: SingleStockViewModel.SingleStockUiState.Success) {
-    with(uiState.stockInformationUiModel) {
-        val spacing = LocalSpacing.current
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(spacing.medium)
-                .statusBarsPadding()
-        ) {
-            Card(
-                shape = RoundedCornerShape(spacing.medium),
-                modifier = Modifier.fillMaxWidth(),
-                elevation = CardDefaults.cardElevation(defaultElevation = spacing.smallest)
-            ) {
-                Column(
-                    modifier = Modifier.padding(spacing.medium),
-                    verticalArrangement = Arrangement.spacedBy(spacing.small)
-                ) {
-                    HeaderSection(title, stockSymbolLabel, exchangeLabel)
-                    Text(
-                        text = priceLabel,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                    PriceMovementSection(
-                        priceMovementTitle = priceMovementTitle,
-                        priceMovementValueLabel = priceMovementValueLabel,
-                        priceMovementColor = priceMovementColor,
-                        priceMovementPercentage = priceMovementPercentage
-                    )
+fun SingleStockScreen(
+    stockInformationUiModel: StockInformationUiModel,
+    graphAnimationEnabled: Boolean = true
+) {
+    val spacing = LocalSpacing.current
 
-                    LineGraph(graphModel)
-                }
-            }
-        }
+    StockCard(
+        modifier = Modifier
+            .statusBarsPadding()
+            .padding(spacing.medium)
+    ) {
+        SingleStockCardContent(
+            stockInformationUiModel = stockInformationUiModel,
+            graphAnimationEnabled = graphAnimationEnabled
+        )
+    }
+}
+
+@Composable
+fun SingleStockCardContent(
+    modifier: Modifier = Modifier,
+    stockInformationUiModel: StockInformationUiModel,
+    graphAnimationEnabled: Boolean = true
+) {
+    with(stockInformationUiModel) {
+        HeaderSection(title, stockSymbolLabel, exchangeLabel)
+        Text(
+            text = priceLabel,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        PriceMovementSection(
+            priceMovementTitle = priceMovementTitle,
+            priceMovementValueLabel = priceMovementValueLabel,
+            priceMovementColor = priceMovementColor,
+            priceMovementPercentage = priceMovementPercentage
+        )
+
+        LineGraph(modifier, graphModel, graphAnimationEnabled)
     }
 }
 
@@ -126,32 +125,11 @@ fun PriceMovementSection(
 @DarkAndLightPreviews
 @Composable
 fun StockScreenDarkThemePreview() {
-    val stockInformationUiModel = StockInformationUiModel(
-        title = "Apple Inc.",
-        stockSymbolLabel = "Symbol: AAPL",
-        exchangeLabel = "Exchange: NASDAQ",
-        priceLabel = "Price: 150.0",
-        priceMovementTitle = "Price Movement",
-        priceMovementPercentage = "+5.0%",
-        priceMovementColor = Green,
-        priceMovementValueLabel = "+10.0",
-        graphModel = GraphUiModel(
-            graphPoints = listOf(
-                156.01,
-                159.24,
-                123.01,
-                178.78,
-                250.01,
-                70.33
-            ),
-            graphHorizontalLabels = listOf("08:31", "08:36", "08:40", "08:45")
-        )
-    )
+    val fakeRepo = FakeRepositoryForPreviews(LocalContext.current)
 
-    val uiState = SingleStockViewModel.SingleStockUiState.Success(stockInformationUiModel)
     MyStockTheme {
         Surface {
-            SingleStockScreen(uiState)
+            SingleStockScreen(fakeRepo.getSingleStockInformationUiModel(), false)
         }
     }
 }

--- a/app/src/main/java/com/section11/mystock/ui/singlestock/graph/composables/StockGraph.kt
+++ b/app/src/main/java/com/section11/mystock/ui/singlestock/graph/composables/StockGraph.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,6 +23,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -29,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.TextUnit
 import com.section11.mystock.framework.utils.DarkAndLightPreviews
+import com.section11.mystock.ui.common.previewsrepositories.FakeRepositoryForPreviews
 import com.section11.mystock.ui.model.GraphUiModel
 import com.section11.mystock.ui.theme.Green40
 import com.section11.mystock.ui.theme.LocalDimens
@@ -53,7 +56,11 @@ private const val GRAPH_ASPECT_RATIO = 3 / 2f
  * graph to work
  */
 @Composable
-fun LineGraph(graphUiModel: GraphUiModel, animationEnabled: Boolean = true) {
+fun LineGraph(
+    modifier: Modifier = Modifier,
+    graphUiModel: GraphUiModel,
+    animationEnabled: Boolean = true
+) {
     val textMeasurer = rememberTextMeasurer()
     val spacing = LocalSpacing.current
     val dimens = LocalDimens.current
@@ -68,7 +75,7 @@ fun LineGraph(graphUiModel: GraphUiModel, animationEnabled: Boolean = true) {
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .padding(spacing.small)
             .fillMaxWidth()
     ) {
@@ -244,23 +251,14 @@ private fun DrawScope.drawHorizontalLines(backgroundHorizontalLines: Int, barWid
 @DarkAndLightPreviews
 @Composable
 fun MyScreen() {
+    val fakeRepo = FakeRepositoryForPreviews(LocalContext.current)
     MyStockTheme {
         Surface {
-            val dataPoints = listOf(
-                100.00,
-                120.05,
-                115.15,
-                129.15,
-                156.15,
-                110.15,
-                300.12
-                // Add more data points here...
+            LineGraph(
+                modifier = Modifier.statusBarsPadding(),
+                fakeRepo.getSingleStockInformationUiModel().graphModel,
+                animationEnabled = false
             )
-            val graphInfo = GraphUiModel(
-                graphPoints = dataPoints,
-                graphHorizontalLabels = listOf("08:31", "08:36", "08:40", "08:45")
-            )
-            LineGraph(graphInfo, animationEnabled = false)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
     <string name="app_name">MyStock</string>
 
+    <!--  Stocks Watchlist  -->
+    <string name="watchlist_stock_tile">%s - %s</string>
+
     <!--  Single Stock Screen String  -->
     <string name="single_stock_screen_symbol_text">Symbol: %s</string>
     <string name="single_stock_screen_exchange_text">"Exchange: %s</string>

--- a/app/src/test/java/com/section11/mystock/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/section11/mystock/ui/home/HomeViewModelTest.kt
@@ -1,10 +1,23 @@
 package com.section11.mystock.ui.home
 
+import com.section11.mystock.domain.StocksInformationUseCase
 import com.section11.mystock.domain.watchlist.StockWatchlistUseCase
 import com.section11.mystock.domain.models.Stock
+import com.section11.mystock.domain.models.StockInformation
+import com.section11.mystock.framework.featureflags.FeatureFlagManager
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Loading
+import com.section11.mystock.ui.home.HomeViewModel.HomeUiState.Success
+import com.section11.mystock.ui.home.HomeViewModel.SingleStockInformationState.FetchedSingleStockInfo
+import com.section11.mystock.ui.model.StockInformationUiModel
+import com.section11.mystock.ui.model.WatchlistStockModel
+import com.section11.mystock.ui.model.mapper.StockInformationUiModelMapper
+import com.section11.mystock.ui.model.mapper.StockWatchlistUiModelMapper
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -15,6 +28,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -22,6 +36,10 @@ import org.mockito.kotlin.whenever
 class HomeViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val stockWatchlistUiModelMapper: StockWatchlistUiModelMapper = mock()
+    private val stocksInformationUseCase: StocksInformationUseCase = mock()
+    private val stockInformationUiModelMapper: StockInformationUiModelMapper = mock()
+    private val featureFlagManager: FeatureFlagManager = mock()
 
     private lateinit var viewModel: HomeViewModel
     private lateinit var stockWatchlistUseCase: StockWatchlistUseCase
@@ -30,7 +48,14 @@ class HomeViewModelTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         stockWatchlistUseCase = mock()
-        viewModel = HomeViewModel(stockWatchlistUseCase, testDispatcher)
+        viewModel = HomeViewModel(
+            stockWatchlistUseCase,
+            stockWatchlistUiModelMapper,
+            stocksInformationUseCase,
+            stockInformationUiModelMapper,
+            featureFlagManager,
+            testDispatcher
+        )
     }
 
     @After
@@ -41,17 +66,22 @@ class HomeViewModelTest {
     @Test
     fun `initial state is loading`() = runTest {
         // Expected
-        Assert.assertEquals(HomeUiState.Loading, viewModel.uiState.value)
+        Assert.assertEquals(Loading, viewModel.uiState.value)
     }
 
     @Test
     fun `getStocks success`() = runTest {
         // Given
-        val expectedStocks = listOf(
+        val stocks = listOf(
             Stock(name = "Stock 1", symbol = "STK1"),
             Stock(name = "Stock 2", symbol = "STK2")
         )
-        whenever(stockWatchlistUseCase.getWatchlist()).thenReturn(flowOf(expectedStocks))
+        val expectedStocks = listOf(
+            WatchlistStockModel(stockTitle = "Stock 1", symbol = "STK1"),
+            WatchlistStockModel(stockTitle = "Stock 2", symbol = "STK2")
+        )
+        whenever(stockWatchlistUseCase.getWatchlist()).thenReturn(flowOf(stocks))
+        whenever(stockWatchlistUiModelMapper.mapToUiModel(any())).thenReturn(expectedStocks)
 
         // When
         viewModel.getStocks()
@@ -59,6 +89,105 @@ class HomeViewModelTest {
 
         // Then
         verify(stockWatchlistUseCase).getWatchlist()
-        Assert.assertEquals(HomeUiState.Success(expectedStocks), viewModel.uiState.value)
+        Assert.assertEquals(Success(expectedStocks), viewModel.uiState.value)
+    }
+
+    @Test
+    fun `onStockTap with valid symbol`() = runTest {
+        // Given
+        whenever(featureFlagManager.isNavigationToSingleStockEnabled()).thenReturn(true)
+        val symbol = "AAPL"
+        val events = mutableListOf<HomeViewModel.NavigationEvent>()
+
+        // Collect the SharedFlow in a coroutine
+        val job = launch {
+            viewModel.navigationEvent.collect { event ->
+                events.add(event)
+            }
+        }
+
+        // when
+        viewModel.onStockTap(symbol)
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(1, events.size)
+        val event = events.first() as HomeViewModel.NavigationEvent.ToSingleStock
+        assertEquals(symbol, event.symbol)
+
+        // Cleanup
+        job.cancel()
+    }
+
+    @Test
+    fun `onStockTap with invalid symbol`() = runTest {
+        // Given
+        whenever(featureFlagManager.isNavigationToSingleStockEnabled()).thenReturn(true)
+
+        // When
+        viewModel.onStockTap(null)
+        advanceUntilIdle()
+
+        assert(viewModel.uiState.value is HomeUiState.Error)
+    }
+
+    @Test
+    fun `onStockTap with Navigation Feature Flag Enabled`() = runTest {
+        // Given
+        whenever(featureFlagManager.isNavigationToSingleStockEnabled()).thenReturn(true)
+        val symbol = "AAPL"
+        val events = mutableListOf<HomeViewModel.NavigationEvent>()
+
+        // Collect the SharedFlow in a coroutine
+        val job = launch {
+            viewModel.navigationEvent.collect { event ->
+                events.add(event)
+            }
+        }
+
+        // when
+        viewModel.onStockTap(symbol)
+        advanceUntilIdle()
+
+        // Then
+        // Then
+        assertEquals(1, events.size)
+        val event = events.first() as HomeViewModel.NavigationEvent.ToSingleStock
+        assertEquals(symbol, event.symbol)
+
+        // Cleanup
+        job.cancel()
+    }
+
+    @Test
+    fun `onStockTap with Navigation Feature Flag Disabled`() = runTest {
+        // Given
+        val mockStockInfo: StockInformation = mock()
+        val mockStockInfoModel: StockInformationUiModel = mock()
+        whenever(featureFlagManager.isNavigationToSingleStockEnabled()).thenReturn(false)
+        whenever(stocksInformationUseCase.getStockInformation(any())).thenReturn(mockStockInfo)
+        whenever(stockInformationUiModelMapper.mapToUiModel(mockStockInfo)).thenReturn(mockStockInfoModel)
+        val symbol = "AAPL"
+        val events = mutableListOf<HomeViewModel.NavigationEvent>()
+
+        // Collect the SharedFlow in a coroutine
+        val job = launch {
+            viewModel.navigationEvent.collect { event ->
+                events.add(event)
+            }
+        }
+
+        // when
+        viewModel.onStockTap(symbol)
+        advanceUntilIdle()
+
+        // Then
+        // Then
+        assertEquals(0, events.size)
+        verify(stocksInformationUseCase).getStockInformation(symbol)
+        assertEquals(FetchedSingleStockInfo(mockStockInfoModel) , viewModel.singleStockInformationState.value)
+
+        // Cleanup
+        job.cancel()
     }
 }

--- a/app/src/test/java/com/section11/mystock/ui/model/mapper/StockWatchlistUiModelMapperTest.kt
+++ b/app/src/test/java/com/section11/mystock/ui/model/mapper/StockWatchlistUiModelMapperTest.kt
@@ -1,0 +1,47 @@
+package com.section11.mystock.ui.model.mapper
+
+import com.section11.mystock.common.resources.ResourceProvider
+import com.section11.mystock.domain.models.Stock
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+class StockWatchlistUiModelMapperTest {
+
+    private val resourceProvider: ResourceProvider = mock()
+
+    private lateinit var mapper: StockWatchlistUiModelMapper
+
+    @Before
+    fun setup() {
+        mapper = StockWatchlistUiModelMapper(resourceProvider)
+    }
+
+    @Test
+    fun `mapToUiModel converts stocks to watchlist stock models`() {
+        val formatedStringMock = "Stock 1 (STK1)"
+        whenever(resourceProvider.getString(any(), any(), any())).thenReturn(formatedStringMock)
+        val name1 = "Stock 1"
+        val name2 = "Stock 2"
+        val symbol1 = "STK1"
+        val symbol2 = "STK2"
+
+        val mockStocksList = listOf(
+            Stock(name1, symbol1),
+            Stock(name2, symbol2)
+        )
+
+        // Then
+        val result = mapper.mapToUiModel(mockStocksList)
+
+        assertEquals(symbol1, result[0].symbol)
+        assertEquals(symbol2, result[1].symbol)
+        assertEquals(formatedStringMock, result[0].stockTitle)
+        assertEquals(formatedStringMock, result[1].stockTitle)
+        assertTrue(result.size == mockStocksList.size)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.04.01"
 detekt = "1.23.5"
+mockkAgent = "1.13.16"
+mockkAndroid = "1.13.16"
 room = "2.6.1"
 ksp = "2.1.0-1.0.29"
 hilt = "2.53.1"
@@ -56,6 +58,8 @@ mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", versio
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "androidx-test-orchestrator" }
+mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockkAgent" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }


### PR DESCRIPTION
The stock watchlist screen now consists of cards, with the same look and feel as the SingleStock Screen but less information.

On tap they can (depending on a feature flag):
- Expand and show the same info as on the SIngleStockInformation screen
- Or navigate to that screen

Changes:
- Added made the card expand on tap instead of navigation
- Navigation to single stock still exists but under a feature flag
- Added FeatureFlagManager
- Added FakeRepositoryForPreviews to centralize mock information for previews
- Added test cases

## How it looks:

https://github.com/user-attachments/assets/2cd2c3cb-84db-4e3d-a1f9-d15368438bc2


